### PR TITLE
Avoid burning the battery uselessly with system TTS (and fix a TOCTOU issue) 

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -124,6 +124,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
+++ b/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
@@ -8,15 +8,22 @@ import com.wxn.bookread.data.model.TextLine
 import com.wxn.bookread.data.source.local.TtsPreferencesUtil
 import com.wxn.reader.util.LanguageInfo
 import com.wxn.reader.util.LanguageUtil
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.gotev.speech.Speech
 import net.gotev.speech.SpeechRecognitionNotAvailable
 import net.gotev.speech.TextToSpeechCallback
 import java.util.Locale
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
+import kotlin.concurrent.timer
 
 class TtsNavigator(
     val context: Context,
@@ -158,15 +165,84 @@ class TtsNavigator(
     //---------------------------
 
     init {
-        Speech.init(context)
+        // Speech.init is now called when needed in getSpeechReady()
     }
 
+    private var isEngineReady = false
+
+    private suspend fun getSpeechReady(): Speech {
+        return withContext(Dispatchers.Main) {
+            if (Speech.isInitialized() && isEngineReady) {
+                Speech.getInstance()
+            } else {
+                isEngineReady = false
+                val initDeferred = CompletableDeferred<Speech>()
+                Speech.init(context, null, object : TextToSpeech.OnInitListener {
+                    override fun onInit(status: Int) {
+                        if (status == TextToSpeech.SUCCESS) {
+                            Logger.d("TtsNavigator::getSpeechReady SUCCESS")
+                            isEngineReady = true
+                            if (!initDeferred.isCompleted) {
+                                initDeferred.complete(Speech.getInstance())
+                            }
+                        } else {
+                            Logger.e("TtsNavigator::getSpeechReady FAILED: status=$status")
+                            isEngineReady = false
+                            if (!initDeferred.isCompleted) {
+                                initDeferred.complete(Speech.getInstance())
+                            }
+                        }
+                    }
+                })
+                initDeferred.await()
+                // Small delay to allow the engine to fully stabilize after SUCCESS
+                delay(100)
+                Speech.getInstance()
+            }
+        }
+    }
+
+    private val navigatorScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     private var ttsLocale : Locale = LanguageUtil.LANG_EN.locale
     private var speed = 1.0f
     private var pitch = 1.0f
 
+    class Timer(private val delayMillis: Long, private val action: () -> Unit) {
+        private var timerJob: Job? = null
+        private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
+        fun startTimer() {
+            timerJob?.cancel()
+            timerJob = scope.launch {
+                delay(delayMillis)
+                action()
+            }
+        }
+
+        fun cancelTimer() {
+            timerJob?.cancel()
+            timerJob = null
+        }
+    }
+    private var unloadEngineTimer : Timer = Timer(300000) {
+        if (Speech.isInitialized()) {
+            navigatorScope.launch {
+                try {
+                    Speech.getInstance().shutdown()
+                    Logger.i("TtsNavigator::unloadEngineTimer engine shut down on Main thread")
+                } catch (e: Exception) {
+                    Logger.e("TtsNavigator::unloadEngineTimer shutdown error: ${e.message}")
+                }
+            }
+        }
+    }
+
     suspend fun play(textLines: List<TextLine>?, onReadLine: (List<TextLine>, Boolean)->Unit) : Int {
         Logger.i("TtsNavigator::play")
+        unloadEngineTimer.cancelTimer()
+        
+        val speech = getSpeechReady()
+        
         var status = 1
         try {
             val ttsPreferences = ttsPreferencesUtil.ttsPreferencesFlow.firstOrNull()
@@ -178,15 +254,17 @@ class TtsNavigator(
                 speed = ttsPreferences.speed
                 pitch = ttsPreferences.pitch
 
-//                val localeSuppported = Speech.getInstance().setLocale(ttsLocale)
+//                val localeSuppported = speech.setLocale(ttsLocale)
 //                if (localeSuppported < 0) {
 //                    return localeSuppported;
 //                }
 //                Logger.d("TtsNavigator::play[language[$ttsLocale]], localeSupported[$localeSuppported]")
-                Speech.getInstance().setTextToSpeechRate(speed)
-                Speech.getInstance().setTextToSpeechPitch(pitch)
-                Speech.getInstance().setTextToSpeechQueueMode(TextToSpeech.QUEUE_ADD)
-                Speech.getInstance().setGetPartialResults(true)
+                withContext(Dispatchers.Main) {
+                    speech.setTextToSpeechRate(speed)
+                    speech.setTextToSpeechPitch(pitch)
+                    speech.setTextToSpeechQueueMode(TextToSpeech.QUEUE_FLUSH) // Reset queue for fresh start
+                    speech.setGetPartialResults(true)
+                }
 
                 var ret  = 1
                 val textLineMap = hashMapOf<Int, ArrayList<TextLine>>()
@@ -211,12 +289,12 @@ class TtsNavigator(
                 for(key in keys) {
                     val lines = textLineMap[key] ?: continue
                     val text = texts.getOrNull(index++) ?: continue
-                    with(Dispatchers.Main) {
+                    withContext(Dispatchers.Main) {
                         onReadLine(lines, true)
                     }
                     ret = innerPlay(text.toString())
                     Logger.d("TtsNavigator::play::innerPlay result[$ret],text[$text], key=$key, index=$index, lines.size[${lines.size}]")
-                    with(Dispatchers.Main) {
+                    withContext(Dispatchers.Main) {
                         onReadLine(lines, false)
                     }
                     if (ret != 1) {
@@ -236,7 +314,8 @@ class TtsNavigator(
         Logger.d("TtsNavigator::innerPlay:text[$text]")
         var start = System.currentTimeMillis()
         return suspendCoroutine { coroutination ->
-            Speech.getInstance().say(text,
+            val speech = Speech.getInstance()
+            speech.say(text,
                 object : TextToSpeechCallback{
                     override fun onStart() {
                         Logger.d("TtsNavigator::innerPlay say callback onStart")
@@ -263,7 +342,12 @@ class TtsNavigator(
         val speechSpeed = speed.coerceIn(0.25f, 2.0f)
         if (speechSpeed != this.speed) {
             this.speed = speechSpeed
-            Speech.getInstance().setTextToSpeechRate(speechSpeed)
+            if (Speech.isInitialized()) {
+                try {
+                    Speech.getInstance().setTextToSpeechRate(speechSpeed)
+                } catch (e: Exception) {
+                }
+            }
 
             Coroutines.scope().launch {
                 ttsPreferencesUtil.ttsPreferencesFlow.firstOrNull()?.let { preferences ->
@@ -279,7 +363,12 @@ class TtsNavigator(
         val speechPitch = pitch.coerceIn(0.25f, 2.0f)
         if (speechPitch != this.pitch) {
             this.pitch = speechPitch
-            Speech.getInstance().setTextToSpeechPitch(speechPitch)
+            if (Speech.isInitialized()) {
+                try {
+                    Speech.getInstance().setTextToSpeechPitch(speechPitch)
+                } catch (e: Exception) {
+                }
+            }
             Coroutines.scope().launch {
                 ttsPreferencesUtil.ttsPreferencesFlow.firstOrNull()?.let { preferences ->
                     preferences.pitch = speechPitch
@@ -293,11 +382,16 @@ class TtsNavigator(
         val newlocale = language?.locale ?: return false
         if (newlocale != this.ttsLocale) {
             this.ttsLocale = newlocale
-            val supportLanguage = Speech.getInstance().setLocale(language.locale)
-            if (supportLanguage < 0) {
-                return false
+            if (Speech.isInitialized()) {
+                try {
+                    val supportLanguage = Speech.getInstance().setLocale(language.locale)
+                    if (supportLanguage < 0) {
+                        return false
+                    }
+                    Logger.d("TtsNavigator::setLanguage::language[$language], supportLanguage[$supportLanguage]")
+                } catch (e: Exception) {
+                }
             }
-            Logger.d("TtsNavigator::setLanguage::language[$language], supportLanguage[$supportLanguage]")
             Coroutines.scope().launch {
                 ttsPreferencesUtil.ttsPreferencesFlow.firstOrNull()?.let { preferences ->
                     preferences.localeCode = language.code
@@ -310,7 +404,17 @@ class TtsNavigator(
 
     fun stop() {
         Logger.i("TtsNavigator::stop")
-        Speech.getInstance().stopTextToSpeech()
+        isEngineReady = false
+        if (Speech.isInitialized()) {
+            try {
+                Speech.getInstance().stopTextToSpeech()
+            } catch (e: Exception) {
+                // Already shutdown or not initialized
+            }
+        }
+
+
+        unloadEngineTimer.startTimer()
     }
 
     fun onDestroy() {

--- a/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
+++ b/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
@@ -2,6 +2,9 @@ package com.wxn.reader.util.tts
 
 import android.content.Context
 import android.speech.tts.TextToSpeech
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.wxn.base.util.Coroutines
 import com.wxn.base.util.Logger
 import com.wxn.bookread.data.model.TextLine
@@ -28,10 +31,11 @@ import kotlin.concurrent.timer
 class TtsNavigator(
     val context: Context,
     val ttsPreferencesUtil: TtsPreferencesUtil
-//    var speed: Float,// 语速
-//    var pitch: Float, //音调
-//    var language: AppLanguage
-) {
+) : DefaultLifecycleObserver {
+
+    init {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
+    }
 
 //    var initSuccess: Boolean = false
 //
@@ -419,7 +423,31 @@ class TtsNavigator(
 
     fun onDestroy() {
         Logger.i("TtsNavigator::onDestroy")
+        ProcessLifecycleOwner.get().lifecycle.removeObserver(this)
         stop()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        Logger.i("TtsNavigator::onStop - App moved to background")
+        if (Speech.isInitialized()) {
+            val speech = Speech.getInstance()
+
+            // Only shutdown if the speech isn't speaking when it goes to background
+            if (speech.isSpeaking) {
+                Logger.i("TtsNavigator::onStop - TTS is speaking, keeping engine loaded")
+                return
+            }
+
+            // Perform actual shutdown if idle
+            try {
+                speech.shutdown()
+                Logger.i("TtsNavigator::onStop - TTS Engine shut down (Idle)")
+            } catch (e: Exception) {
+                Logger.e("TtsNavigator::onStop shutdown error: ${e.message}")
+            }
+            isEngineReady = false
+            unloadEngineTimer.cancelTimer()
+        }
     }
 //
 //    fun isPlaying() : Boolean {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,7 @@ hilt-compiler = { module = "com.google.dagger:hilt-compiler", version.ref = "hil
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }

--- a/text2speech/src/main/java/net/gotev/speech/Speech.java
+++ b/text2speech/src/main/java/net/gotev/speech/Speech.java
@@ -29,7 +29,7 @@ import java.util.*;
  */
 public class Speech {
 
-    private static Speech instance = null;
+    private static volatile Speech instance = null;
     protected static String GOOGLE_APP_PACKAGE = "com.google.android.googlequicksearchbox";
 
     private Context mContext;
@@ -88,6 +88,11 @@ public class Speech {
     public static Speech init(final Context context, final String callingPackage, TextToSpeech.OnInitListener onInitListener) {
         if (instance == null) {
             instance = new Speech(context, callingPackage, onInitListener, new BaseSpeechRecognitionEngine(), new BaseTextToSpeechEngine());
+        } else {
+            if (onInitListener != null) {
+                // Already initialized, notify the listener immediately
+                onInitListener.onInit(TextToSpeech.SUCCESS);
+            }
         }
 
         return instance;
@@ -96,6 +101,10 @@ public class Speech {
     public static Speech init(final Context context, final String callingPackage, TextToSpeech.OnInitListener onInitListener, SpeechRecognitionEngine speechRecognitionEngine, TextToSpeechEngine textToSpeechEngine) {
         if (instance == null) {
             instance = new Speech(context, callingPackage, onInitListener, speechRecognitionEngine, textToSpeechEngine);
+        } else {
+            if (onInitListener != null) {
+                onInitListener.onInit(TextToSpeech.SUCCESS);
+            }
         }
 
         return instance;
@@ -104,7 +113,7 @@ public class Speech {
     /**
      * Must be called inside Activity's onDestroy.
      */
-    public synchronized void shutdown() {
+    public void shutdown() {
         speechRecognitionEngine.shutdown();
         textToSpeechEngine.shutdown();
 
@@ -122,6 +131,15 @@ public class Speech {
         }
 
         return instance;
+    }
+
+    /**
+     * Checks if the speech recognition has been initialized.
+     *
+     * @return true if initialized, false otherwise
+     */
+    public static boolean isInitialized() {
+        return instance != null;
     }
 
     /**

--- a/text2speech/src/main/java/net/gotev/speech/engine/BaseTextToSpeechEngine.java
+++ b/text2speech/src/main/java/net/gotev/speech/engine/BaseTextToSpeechEngine.java
@@ -11,6 +11,7 @@ import net.gotev.speech.TextToSpeechCallback;
 import net.gotev.speech.TtsProgressListener;
 import com.wxn.base.util.Logger;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.*;
 
 public class BaseTextToSpeechEngine implements TextToSpeechEngine {
@@ -26,7 +27,7 @@ public class BaseTextToSpeechEngine implements TextToSpeechEngine {
     private int mTtsQueueMode = TextToSpeech.QUEUE_FLUSH;
     private int mAudioStream = TextToSpeech.Engine.DEFAULT_STREAM;
 
-    private final Map<String, TextToSpeechCallback> mTtsCallbacks = new HashMap<>();
+    private final Map<String, TextToSpeechCallback> mTtsCallbacks = new ConcurrentHashMap<>();
 
     @Override
     public void initTextToSpeech(Context context) {
@@ -35,18 +36,30 @@ public class BaseTextToSpeechEngine implements TextToSpeechEngine {
         }
 
         mTtsProgressListener = new TtsProgressListener(context, mTtsCallbacks);
-        mTextToSpeech = new TextToSpeech(context.getApplicationContext(), mTttsInitListener);
-        mTextToSpeech.setOnUtteranceProgressListener(mTtsProgressListener);
-        mTextToSpeech.setLanguage(mLocale);
-        mTextToSpeech.setPitch(mTtsPitch);
-        mTextToSpeech.setSpeechRate(mTtsRate);
+        mTextToSpeech = new TextToSpeech(context.getApplicationContext(), new TextToSpeech.OnInitListener() {
+            @Override
+            public void onInit(int status) {
+                    if (status == TextToSpeech.SUCCESS) {
+                        Logger.INSTANCE.d("BaseTextToSpeechEngine: TextToSpeech initialized successfully");
+                        mTextToSpeech.setLanguage(mLocale);
+                        mTextToSpeech.setPitch(mTtsPitch);
+                        mTextToSpeech.setSpeechRate(mTtsRate);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            if (voice == null) {
-                voice = mTextToSpeech.getDefaultVoice();
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                            if (voice != null) {
+                                mTextToSpeech.setVoice(voice);
+                            }
+                        }
+                        mTextToSpeech.setOnUtteranceProgressListener(mTtsProgressListener);
+                    } else {
+                        Logger.INSTANCE.e("BaseTextToSpeechEngine: TextToSpeech initialization failed with status: " + status);
+                    }
+
+                if (mTttsInitListener != null) {
+                    mTttsInitListener.onInit(status);
+                }
             }
-            mTextToSpeech.setVoice(voice);
-        }
+        });
     }
 
     @Override
@@ -80,15 +93,33 @@ public class BaseTextToSpeechEngine implements TextToSpeechEngine {
             mTtsCallbacks.put(utteranceId, callback);
         }
 
+        if (mTextToSpeech == null) {
+            Logger.INSTANCE.e(getClass().getSimpleName() + " say: mTextToSpeech is null!");
+            if (callback != null) {
+                mTtsCallbacks.remove(utteranceId);
+                callback.onError();
+            }
+            return;
+        }
+
+        int result;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             final Bundle params = new Bundle();
             params.putString(TextToSpeech.Engine.KEY_PARAM_STREAM, String.valueOf(mAudioStream));
-            mTextToSpeech.speak(message, mTtsQueueMode, params, utteranceId);
+            result = mTextToSpeech.speak(message, mTtsQueueMode, params, utteranceId);
         } else {
             final HashMap<String, String> params = new HashMap<>();
             params.put(TextToSpeech.Engine.KEY_PARAM_STREAM, String.valueOf(mAudioStream));
             params.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, utteranceId);
-            mTextToSpeech.speak(message, mTtsQueueMode, params);
+            result = mTextToSpeech.speak(message, mTtsQueueMode, params);
+        }
+
+        if (result != TextToSpeech.SUCCESS) {
+            Logger.INSTANCE.e(getClass().getSimpleName() + " speak failed with error code: " + result);
+            if (callback != null) {
+                mTtsCallbacks.remove(utteranceId);
+                callback.onError();
+            }
         }
     }
 
@@ -99,6 +130,8 @@ public class BaseTextToSpeechEngine implements TextToSpeechEngine {
                 mTtsCallbacks.clear();
                 mTextToSpeech.stop();
                 mTextToSpeech.shutdown();
+                mTextToSpeech = null;
+                mTtsProgressListener = null;
             } catch (final Exception exc) {
                 Logger.INSTANCE.e(getClass().getSimpleName() + "Warning while de-initing text to speech" + exc);
             }


### PR DESCRIPTION
The TTSEngine is a system service that was initially started when the reader activity started and never shutdown.

With large TTS engine (making use of NN), this leaves a system process and GPU instance active while the system TTSEngine is instantiated, draining the battery.

This change updates the logic of the Reader's system TTS engine to only init the engine when it's being clicked and automatically shutdown the engine 300s after it's stopped (so in case it's paused and restarted often, we don't pay the engine initialization twice)

I've checked that it doesn't cause issues in the TTS experience and, in fact, it works better than before since there was a bug previously when one could press the "speak" button before the Speech engine is completely initialized and then it wouldn't play more than a single utterance since the callback, speed and pitch were reset when the engine actually finished initializing. Initialization of parameters should have happened in the `onInit` callback and this PR now does that. 