### PR TITLE
Fix tts woes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -327,6 +327,7 @@ dependencies {
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
+    implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app/src/main/java/com/wxn/reader/di/AppModule.kt
+++ b/app/src/main/java/com/wxn/reader/di/AppModule.kt
@@ -105,7 +105,6 @@ import com.wxn.reader.util.TtsServiceController
 import com.wxn.reader.util.download.OKHttpStringStreamer
 import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
-import com.wxn.reader.util.tts.TtsNavigator
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -583,12 +582,6 @@ object AppModule {
     @Singleton
     fun providePermissionRepository(application: Application): PermissionRepository =
         PermissionRepositoryImpl(application)
-
-    @Provides
-    @Singleton
-    fun provideTtsNavigator(application: Application,
-                            ttsPreferencesUtil: TtsPreferencesUtil) : TtsNavigator =
-        TtsNavigator(application, ttsPreferencesUtil)
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/wxn/reader/presentation/mainReader/TTSController.kt
+++ b/app/src/main/java/com/wxn/reader/presentation/mainReader/TTSController.kt
@@ -60,12 +60,15 @@ abstract class TTSController(
     
     private fun isTtsAvailable(): Boolean {
         return try {
-            val tts = android.speech.tts.TextToSpeech(context) { status ->
-                // 只检查初始化状态
-            }
-            val available = tts.engines.isNotEmpty()
-            tts.shutdown()
-            available
+            // Query installed TTS engines through PackageManager rather than constructing a
+            // TextToSpeech. The TextToSpeech constructor binds to the default engine
+            // asynchronously; calling shutdown() on the next line (before onInit fires) races
+            // the bind and can leave an orphaned ServiceConnection that keeps the system TTS
+            // engine alive with nothing left to release it. The manifest already declares a
+            // <queries> entry for android.intent.action.TTS_SERVICE, so these services stay
+            // visible under package-visibility filtering (API 30+).
+            val intent = android.content.Intent(android.speech.tts.TextToSpeech.Engine.INTENT_ACTION_TTS_SERVICE)
+            context.packageManager.queryIntentServices(intent, 0).isNotEmpty()
         } catch (e: Exception) {
             Logger.e("检查TTS可用性失败: ${e.message}")
             false

--- a/app/src/main/java/com/wxn/reader/service/TtsPlaybackService.kt
+++ b/app/src/main/java/com/wxn/reader/service/TtsPlaybackService.kt
@@ -480,6 +480,11 @@ class TtsPlaybackService : MediaSessionService() {
                 val speakSentences = ttsStateHolder.getSentences()
                 val startIndex = ttsStateHolder.getCurrentPosition().second
                 navigator.setSpeakSentences(speakSentences, startIndex)
+                // New chapter data (e.g. an auto-advance to the next chapter) has just updated
+                // bookTitle/chapterTitle in the state. Refresh the MediaSession metadata + the
+                // notification so external surfaces (lock screen, Bluetooth player) show the new
+                // chapter instead of the one that was playing when playback started.
+                updateState(ttsStateHolder.state.value)
             }
 
             ACTION_SET_SPEED -> {
@@ -550,19 +555,23 @@ class TtsPlaybackService : MediaSessionService() {
 
                         if (initStatus == TtsEngineStatus.READY) {
                             Logger.d("TtsPlaybackService::initStatus=$initStatus,then invoke play")
+                            if (config.engineType == 0) {
+                                // Query supported languages only AFTER the engine is READY.
+                                // Previously this ran concurrently with setEngineInfo(): both paths
+                                // called into engine init, each opened a TextToSpeech connection to
+                                // the system engine, and the orphaned one was never shut down -
+                                // keeping the engine process bound forever (the orea leak).
+                                navigator.getSupportedLanguage { languages ->
+                                    if (languages.isNotEmpty()) {
+                                        ttsStateHolder.updateLanguages(languages)
+                                    }
+                                }
+                            }
                             scope.launchMain {
                                 ttsStateHolder.startTimerSession()
                                 navigator.play()
                                 mediaSession?.player?.play()
                                 updateState(ttsStateHolder.state.value)
-                            }
-                        }
-                    }
-
-                    if (config.engineType == 0) {
-                        navigator.getSupportedLanguage { languages ->
-                            if (languages.isNotEmpty()) {
-                                ttsStateHolder.updateLanguages(languages)
                             }
                         }
                     }

--- a/app/src/main/java/com/wxn/reader/util/TtsServiceController.kt
+++ b/app/src/main/java/com/wxn/reader/util/TtsServiceController.kt
@@ -287,12 +287,7 @@ class TtsServiceController @Inject constructor(
             putExtra(EXTRA_SPEED, validSpeed)
         }
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-
-            } else {
-                context.startService(intent)
-            }
+            launchServiceIntent(context, intent)
             // 立即更新状态（乐观更新）
             stateHolder.update { it.copy(speed = validSpeed) }
             onComplete(true)
@@ -327,11 +322,7 @@ class TtsServiceController @Inject constructor(
             putExtra(EXTRA_PITCH, validPitch)
         }
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
-            }
+            launchServiceIntent(context, intent)
             // 立即更新状态（乐观更新）
             stateHolder.update { it.copy(pitch = validPitch) }
             onComplete(true)
@@ -397,11 +388,7 @@ class TtsServiceController @Inject constructor(
             putExtra(EXTRA_SPEAKER_INDEX, speakerIndex)
         }
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
-            }
+            launchServiceIntent(context, intent)
             // 立即更新状态（乐观更新）
             stateHolder.update { it.copy(modelSpeaker = speakerIndex) }
             onComplete(true)
@@ -425,11 +412,7 @@ class TtsServiceController @Inject constructor(
             putExtra(EXTRA_LANG, newlocale)
         }
         try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
-            }
+            launchServiceIntent(context, intent)
             // 立即更新状态（乐观更新）
             stateHolder.update { it.copy(language = newlocale) }
             onComplete(true)
@@ -459,16 +442,20 @@ class TtsServiceController @Inject constructor(
 
         // ... 启动服务
         return try {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                context.startForegroundService(intent)
-            } else {
-                context.startService(intent)
-            }
+            launchServiceIntent(context, intent)
             true
         } catch (e: Exception) {
             Logger.w("发送命令失败 [$action]: ${e.message}")
             stateHolder.reportError(error, context)
             false
+        }
+    }
+
+    private fun launchServiceIntent(context: Context, intent: Intent) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.startForegroundService(intent)
+        } else {
+            context.startService(intent)
         }
     }
 
@@ -484,11 +471,7 @@ class TtsServiceController @Inject constructor(
 
     private fun startAndBindService(context: Context) {
         val intent = Intent(context, TtsPlaybackService::class.java)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.startForegroundService(intent)
-        } else {
-            context.startService(intent)
-        }
+        launchServiceIntent(context, intent)
         context.bindService(intent, this, Context.BIND_AUTO_CREATE)
     }
 

--- a/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
+++ b/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
@@ -114,6 +114,13 @@ class TtsNavigator(
 
     private val mutex = Mutex()
 
+    // Serializes engine creation. Both ensureEngineInitialized() (called on demand by play /
+    // setSpeed / setPitch / setLanguage / setSpeakerIndex / getSupportedLanguage) and
+    // setEngineInfo() create the engine when `speech == null`. Without a lock two of them can
+    // pass the null-check concurrently, each open a TextToSpeech connection to the system engine,
+    // and `speech` keeps only the last one assigned - orphaning the other so shutdown() can never
+    // release it, leaving the engine process bound forever. Hold this across the check + creation.
+    private val engineInitMutex = Mutex()
 
     private val engineInitDeferredRef = AtomicReference(CompletableDeferred<Unit>())
 
@@ -179,38 +186,46 @@ class TtsNavigator(
     private suspend fun ensureEngineInitialized(): Boolean {
         if (speech != null) return true
         if (isShutdown) return false
-        val config = lastEngineConfig ?: return false
 
-        Logger.i("TtsNavigator: re-initializing engine on demand")
-        val deferred = CompletableDeferred<Unit>()
-        engineInitDeferredRef.set(deferred)
+        return engineInitMutex.withLock {
+            // Re-check under the lock: setEngineInfo() or another on-demand caller may have
+            // created the engine while we waited. Creating a second one here would leak a
+            // TextToSpeech connection (see engineInitMutex).
+            if (speech != null) return@withLock true
+            if (isShutdown) return@withLock false
+            val config = lastEngineConfig ?: return@withLock false
 
-        return suspendCancellableCoroutine { continuation ->
-            val job = scope.launchIO {
-                if (config.engineType == 1) {
-                    if (validTtsConfig(config.engineType, config.modelConfig)) {
-                        speech = Speech.init(context, config.engineType, config.modelConfig, config.speed, config.pitch, config.language, config.speakerIndex) { status ->
-                            handleInitResult(deferred, status, "SherpaOnnx")
+            Logger.i("TtsNavigator: re-initializing engine on demand")
+            val deferred = CompletableDeferred<Unit>()
+            engineInitDeferredRef.set(deferred)
+
+            suspendCancellableCoroutine { continuation ->
+                val job = scope.launchIO {
+                    if (config.engineType == 1) {
+                        if (validTtsConfig(config.engineType, config.modelConfig)) {
+                            speech = Speech.init(context, config.engineType, config.modelConfig, config.speed, config.pitch, config.language, config.speakerIndex) { status ->
+                                handleInitResult(deferred, status, "SherpaOnnx")
+                                releaseEngineIfShutdownRequested()
+                                if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS && !isShutdown)
+                            }
+                        } else {
+                            handleInitResult(deferred, TextToSpeech.ERROR, "SherpaOnnx")
+                            if (continuation.isActive) continuation.resume(false)
+                        }
+                    } else {
+                        speech = Speech.init(context, config.speed, config.pitch, config.language) { status ->
+                            handleInitResult(deferred, status, "BaseTTS")
                             releaseEngineIfShutdownRequested()
                             if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS && !isShutdown)
                         }
-                    } else {
-                        handleInitResult(deferred, TextToSpeech.ERROR, "SherpaOnnx")
-                        if (continuation.isActive) continuation.resume(false)
-                    }
-                } else {
-                    speech = Speech.init(context, config.speed, config.pitch, config.language) { status ->
-                        handleInitResult(deferred, status, "BaseTTS")
-                        releaseEngineIfShutdownRequested()
-                        if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS && !isShutdown)
                     }
                 }
+                engineInitJob = job
+                // Best-effort: if the job hasn't started the synchronous Speech.init(...) call yet,
+                // this prevents it from starting at all. If it already has, releaseEngineIfShutdownRequested()
+                // inside the onInit callback above is the guaranteed fallback.
+                continuation.invokeOnCancellation { job.cancel() }
             }
-            engineInitJob = job
-            // Best-effort: if the job hasn't started the synchronous Speech.init(...) call yet,
-            // this prevents it from starting at all. If it already has, releaseEngineIfShutdownRequested()
-            // inside the onInit callback above is the guaranteed fallback.
-            continuation.invokeOnCancellation { job.cancel() }
         }
     }
 
@@ -678,26 +693,34 @@ class TtsNavigator(
             val oldModelConfig = speech?.config
             if (oldEngineType != engineType) {  //系统引擎 <-->  Sherpa引擎  两者之间切换
                 if (oldEngineType == -1 || speech == null) {  //还没有引擎 ,第一次初始化引擎
-                    val newDeferred = CompletableDeferred<Unit>()
-                    engineInitDeferredRef.set(newDeferred)
-
-                    if (engineType == 1) {
-                        if (validTtsConfig(engineType, modelConfig)) {
-                            speech = Speech.init(context, engineType, modelConfig, speed, pitch, language, speakerIndex) { status ->
-                                handleInitResult(newDeferred, status, "SherpaOnnx") //  通知等待者
-                                releaseEngineIfShutdownRequested()
-                                onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
-                            }
+                    engineInitMutex.withLock {
+                        if (speech != null) {
+                            // A concurrent on-demand initializer created the engine while we waited
+                            // for the lock; reuse it instead of opening a second connection.
+                            onInit(if (isShutdown) TtsEngineStatus.FAILED else TtsEngineStatus.READY)
                         } else {
-                            onInit(TtsEngineStatus.NEED_MODEL)
-                            ToastUtil.showLong(stringResource(com.wxn.reader.R.string.err_no_valid_engine_model))
-                            handleInitResult(newDeferred, TextToSpeech.ERROR, "SherpaOnnx")
-                        }
-                    } else {
-                        speech = Speech.init(context, speed, pitch, language) { status ->
-                            handleInitResult(newDeferred, status, "BaseTTS")
-                            releaseEngineIfShutdownRequested()
-                            onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                            val newDeferred = CompletableDeferred<Unit>()
+                            engineInitDeferredRef.set(newDeferred)
+
+                            if (engineType == 1) {
+                                if (validTtsConfig(engineType, modelConfig)) {
+                                    speech = Speech.init(context, engineType, modelConfig, speed, pitch, language, speakerIndex) { status ->
+                                        handleInitResult(newDeferred, status, "SherpaOnnx") //  通知等待者
+                                        releaseEngineIfShutdownRequested()
+                                        onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                    }
+                                } else {
+                                    onInit(TtsEngineStatus.NEED_MODEL)
+                                    ToastUtil.showLong(stringResource(com.wxn.reader.R.string.err_no_valid_engine_model))
+                                    handleInitResult(newDeferred, TextToSpeech.ERROR, "SherpaOnnx")
+                                }
+                            } else {
+                                speech = Speech.init(context, speed, pitch, language) { status ->
+                                    handleInitResult(newDeferred, status, "BaseTTS")
+                                    releaseEngineIfShutdownRequested()
+                                    onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                }
+                            }
                         }
                     }
                 } else {  //有其他引擎, 先关闭其他引擎

--- a/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
+++ b/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
@@ -3,6 +3,9 @@ package com.wxn.reader.util.tts
 import android.content.Context
 import android.media.AudioManager
 import android.speech.tts.TextToSpeech
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import com.wxn.base.bean.EngineModelConfig
 import com.wxn.base.bean.Locator
 import com.wxn.base.bean.SpeakSentence
@@ -42,7 +45,20 @@ import kotlin.coroutines.suspendCoroutine
 class TtsNavigator(
     val context: Context,
     val ttsPreferencesUtil: TtsPreferencesUtil
-) : ITtsNavigator {
+) : ITtsNavigator, DefaultLifecycleObserver {
+
+    private data class EngineConfig(
+        val engineType: Int,
+        val modelConfig: EngineModelConfig?,
+        val speed: Float,
+        val pitch: Float,
+        val language: Locale,
+        val speakerIndex: Int
+    )
+
+    private var lastEngineConfig: EngineConfig? = null
+    private var shutdownTimerJob: Job? = null
+    private val INACTIVITY_TIMEOUT_MS = 60_000L // 60s
 
     companion object {
         const val TTS_MIN_SPEED = 0.25f
@@ -93,6 +109,80 @@ class TtsNavigator(
 
     private var speech: Speech? = null
 
+    init {
+        scope.launch {
+            ProcessLifecycleOwner.get().lifecycle.addObserver(this@TtsNavigator)
+        }
+    }
+
+    private fun startShutdownTimer() {
+        shutdownTimerJob?.cancel()
+        shutdownTimerJob = scope.launchIO {
+            Logger.d("TtsNavigator: starting shutdown timer for ${INACTIVITY_TIMEOUT_MS / 1000}s")
+            delay(INACTIVITY_TIMEOUT_MS)
+            if (speech != null && !isPlaying()) {
+                Logger.i("TtsNavigator: inactivity timer expired, releasing engine")
+                releaseEngine()
+            }
+        }
+    }
+
+    private fun resetShutdownTimer() {
+        if (shutdownTimerJob != null) {
+            startShutdownTimer()
+        }
+    }
+
+    private fun cancelShutdownTimer() {
+        shutdownTimerJob?.cancel()
+        shutdownTimerJob = null
+    }
+
+    private fun releaseEngine() {
+        Logger.i("TtsNavigator: releasing engine")
+        speech?.shutdown(null)
+        speech = null
+        cancelShutdownTimer()
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        super.onStop(owner)
+        Logger.i("TtsNavigator: App went to background, releasing engine if not playing")
+        if (!isPlaying()) {
+            releaseEngine()
+        }
+    }
+
+    private suspend fun ensureEngineInitialized(): Boolean {
+        if (speech != null) return true
+        val config = lastEngineConfig ?: return false
+        
+        Logger.i("TtsNavigator: re-initializing engine on demand")
+        val deferred = CompletableDeferred<Unit>()
+        engineInitDeferredRef.set(deferred)
+
+        return suspendCancellableCoroutine { continuation ->
+            scope.launchIO {
+                if (config.engineType == 1) {
+                    if (validTtsConfig(config.engineType, config.modelConfig)) {
+                        speech = Speech.init(context, config.engineType, config.modelConfig, config.speed, config.pitch, config.language, config.speakerIndex) { status ->
+                            handleInitResult(deferred, status, "SherpaOnnx")
+                            if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS)
+                        }
+                    } else {
+                        handleInitResult(deferred, TextToSpeech.ERROR, "SherpaOnnx")
+                        if (continuation.isActive) continuation.resume(false)
+                    }
+                } else {
+                    speech = Speech.init(context, config.speed, config.pitch, config.language) { status ->
+                        handleInitResult(deferred, status, "BaseTTS")
+                        if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS)
+                    }
+                }
+            }
+        }
+    }
+
     private suspend fun <T> withState(block: suspend () -> T): T = mutex.withLock { block() }
 
     private suspend fun replaceSentences(sentences: List<SpeakSentence>, startIndex: Int) {
@@ -105,6 +195,7 @@ class TtsNavigator(
 
     override fun skipToPreviousUtterance(): Boolean {
         Logger.i("TtsNavigator:skipToPreviousUtterance")
+        resetShutdownTimer()
         if (true != speech?.isSpeaking) {
             Logger.i("TtsNavigator:skipToPreviousUtterance:isNotSpeaking, pass")
             return false
@@ -127,6 +218,7 @@ class TtsNavigator(
 
     override fun skipToNextUtterance(): Boolean {
         Logger.i("TtsNavigator:skipToNextUtterance")
+        resetShutdownTimer()
         if (true != speech?.isSpeaking) {
             Logger.d("TtsNavigator:skipToNextUtterance:is not speaking, pass")
             return false
@@ -148,6 +240,7 @@ class TtsNavigator(
 
     override fun setSpeakSentences(sentences: List<SpeakSentence>, startSentenceIndex: Int) {
         Logger.i("TtsNavigator::setSpeakSentences:sentences.size=${sentences.size},startSentenceIndex=$startSentenceIndex")
+        resetShutdownTimer()
         scope.launchIO {
             withState {
                 replaceSentences(sentences, startSentenceIndex)
@@ -162,10 +255,16 @@ class TtsNavigator(
 
     override fun play() {
         Logger.i("TtsNavigator:play")
+        cancelShutdownTimer()
         playJob?.cancel()
         Logger.i("TtsNavigator:play:cancel old playJob")
         playJob = scope.launchIO {
             Logger.i("TtsNavigator:play:into io coroutine and then wait for init")
+            if (!ensureEngineInitialized()) {
+                Logger.e("TtsNavigator:play: engine initialization failed")
+                callback?.onFinished(STATUS_ERROR)
+                return@launchIO
+            }
             waitForInit()
             Logger.i("TtsNavigator:play: engine init is success, then continue")
 
@@ -206,6 +305,7 @@ class TtsNavigator(
                 }
 
                 // 播放句子（挂起直到播放完成）
+                resetShutdownTimer()
                 val result = innerPlay(sentence)
 
                 Logger.d("TtsNavigator::play:play result=[$result],check agian:isActive=$isActive")
@@ -375,10 +475,12 @@ class TtsNavigator(
 
     override fun setSpeed(speed: Float) {
         Logger.i("TtsNavigator::setSpeed:speed=$speed, oldSpeed=${this.speed}")
+        resetShutdownTimer()
         val speechSpeed = speed.coerceIn(TTS_MIN_SPEED, TTS_MAX_SPEED)
         if (speechSpeed != this.speed) {
             scope.launchIO {
                 Logger.d("TtsNavigator::setSpeed: try to wait engine init")
+                if (!ensureEngineInitialized()) return@launchIO
                 waitForInit()
                 Logger.d("TtsNavigator::setSpeed: engine init done, continue")
                 if (speech?.setTextToSpeechRate(speechSpeed) == TextToSpeech.SUCCESS) {
@@ -427,11 +529,13 @@ class TtsNavigator(
 
     override fun setPitch(pitch: Float) {
         Logger.i("TtsNavigator:setPitch:pitch[$pitch],ttsPitch[${this.pitch}]]")
+        resetShutdownTimer()
 
         val speechPitch = pitch.coerceIn(TTS_MIN_PITCH, TTS_MAX_PITCH)
         if (speechPitch != this.pitch) {
             scope.launchIO {
                 Logger.d("TtsNavigator:setPitch: try to wait engine init")
+                if (!ensureEngineInitialized()) return@launchIO
                 waitForInit()
                 Logger.d("TtsNavigator:setPitch: engine init done, continue")
                 if (speech?.setTextToSpeechPitch(speechPitch) == TextToSpeech.SUCCESS) {
@@ -456,6 +560,10 @@ class TtsNavigator(
 
     override fun getSupportedLanguage(onDataCollect: (Set<Locale>) -> Unit) {
         scope.launchIO {
+            if (!ensureEngineInitialized()) {
+                onDataCollect.invoke(emptySet())
+                return@launchIO
+            }
             waitForInit()
             val locales = speech?.supportedTtsLanguages
             onDataCollect.invoke(locales ?: emptySet<Locale>())
@@ -464,8 +572,13 @@ class TtsNavigator(
 
     override fun setLanguage(newlocale: Locale, onLanguageChanged: (Boolean) -> Unit) {
         Logger.i("TtsNavigator:setLanguage:newLocale[${newlocale.language}],ttsLocale[${ttsLocale.language}]]")
+        resetShutdownTimer()
         scope.launchIO {
             Logger.i("TtsNavigator:setLanguage: try to wait engine init")
+            if (!ensureEngineInitialized()) {
+                onLanguageChanged.invoke(false)
+                return@launchIO
+            }
             waitForInit()
             Logger.i("TtsNavigator:setLanguage: engine init done, continue")
             if (newlocale != this@TtsNavigator.ttsLocale) {
@@ -504,8 +617,10 @@ class TtsNavigator(
 
     override fun setSpeakerIndex(index: Int) {
         Logger.i("TtsNavigator:setSpeakerIndex:index=$index")
+        resetShutdownTimer()
         scope.launchIO {
             Logger.i("TtsNavigator:setSpeakerIndex: try to wait engine init")
+            if (!ensureEngineInitialized()) return@launchIO
             waitForInit()
             Logger.i("TtsNavigator:setSpeakerIndex: engine init done, continue")
             speech?.setSpeakerIndex(index)
@@ -524,6 +639,8 @@ class TtsNavigator(
         onInit: (TtsEngineStatus) -> Unit) {
         Logger.i("TtsNavigator:setEngineInfo:engineType=$engineType,config=$modelConfig," +
                 "speed=$speed,pitch=$pitch,language=$language,speakerIndex=$speakerIndex")
+        lastEngineConfig = EngineConfig(engineType, modelConfig, speed, pitch, language, speakerIndex)
+        cancelShutdownTimer()
         scope.launchIO {  //切换到协程中执行
             val oldEngineType = speech?.engineType ?: -1
             val oldModelConfig = speech?.config
@@ -690,6 +807,7 @@ class TtsNavigator(
         playJob?.cancel()
         playJob = null
         speech?.stopTextToSpeech()
+        startShutdownTimer()
     }
 
     private suspend fun pauseAndWait() {
@@ -697,6 +815,7 @@ class TtsNavigator(
         playJob?.cancel()
         playJob = null
         speech?.stopAndWait()
+        startShutdownTimer()
     }
 
     override fun resume() {
@@ -714,6 +833,7 @@ class TtsNavigator(
         playJob?.cancel()
         playJob = null
         speech?.stopTextToSpeech()
+        startShutdownTimer()
 
         scope.launchIO {
             withState {
@@ -730,6 +850,7 @@ class TtsNavigator(
     override fun shutdown(listener: OnShutdownListener?) {
         Logger.i("TtsNavigator:shutdown")
         playJob?.cancel()
+        cancelShutdownTimer()
 
         // 关闭 Channel
         try {

--- a/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
+++ b/app/src/main/java/com/wxn/reader/util/tts/TtsNavigator.kt
@@ -60,6 +60,16 @@ class TtsNavigator(
     private var shutdownTimerJob: Job? = null
     private val INACTIVITY_TIMEOUT_MS = 60_000L // 60s
 
+    // Tracks the in-flight async Speech.init(...) job so shutdown() can cancel it.
+    private var engineInitJob: Job? = null
+
+    // Set for good once shutdown() has been called on this instance. Read from both the
+    // main thread (shutdown/stop callers) and the IO dispatcher (engine-init callbacks),
+    // so it guards against Speech.init(...) completing right after teardown and leaving a
+    // live, never-to-be-released TextToSpeech engine bound to the system TTS service.
+    @Volatile
+    private var isShutdown = false
+
     companion object {
         const val TTS_MIN_SPEED = 0.25f
         const val TTS_MAX_SPEED = 3f
@@ -145,6 +155,19 @@ class TtsNavigator(
         cancelShutdownTimer()
     }
 
+    /**
+     * Must be called right after a Speech.init(...) completion callback fires. If shutdown()
+     * ran while that init was in flight, the engine it just created would otherwise be left
+     * live and bound with nothing left to ever release it - this closes that window.
+     */
+    private fun releaseEngineIfShutdownRequested() {
+        if (isShutdown && speech != null) {
+            Logger.w("TtsNavigator: engine finished initializing after shutdown, releasing it immediately")
+            speech?.shutdown(null)
+            speech = null
+        }
+    }
+
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
         Logger.i("TtsNavigator: App went to background, releasing engine if not playing")
@@ -155,19 +178,21 @@ class TtsNavigator(
 
     private suspend fun ensureEngineInitialized(): Boolean {
         if (speech != null) return true
+        if (isShutdown) return false
         val config = lastEngineConfig ?: return false
-        
+
         Logger.i("TtsNavigator: re-initializing engine on demand")
         val deferred = CompletableDeferred<Unit>()
         engineInitDeferredRef.set(deferred)
 
         return suspendCancellableCoroutine { continuation ->
-            scope.launchIO {
+            val job = scope.launchIO {
                 if (config.engineType == 1) {
                     if (validTtsConfig(config.engineType, config.modelConfig)) {
                         speech = Speech.init(context, config.engineType, config.modelConfig, config.speed, config.pitch, config.language, config.speakerIndex) { status ->
                             handleInitResult(deferred, status, "SherpaOnnx")
-                            if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS)
+                            releaseEngineIfShutdownRequested()
+                            if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS && !isShutdown)
                         }
                     } else {
                         handleInitResult(deferred, TextToSpeech.ERROR, "SherpaOnnx")
@@ -176,10 +201,16 @@ class TtsNavigator(
                 } else {
                     speech = Speech.init(context, config.speed, config.pitch, config.language) { status ->
                         handleInitResult(deferred, status, "BaseTTS")
-                        if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS)
+                        releaseEngineIfShutdownRequested()
+                        if (continuation.isActive) continuation.resume(status == TextToSpeech.SUCCESS && !isShutdown)
                     }
                 }
             }
+            engineInitJob = job
+            // Best-effort: if the job hasn't started the synchronous Speech.init(...) call yet,
+            // this prevents it from starting at all. If it already has, releaseEngineIfShutdownRequested()
+            // inside the onInit callback above is the guaranteed fallback.
+            continuation.invokeOnCancellation { job.cancel() }
         }
     }
 
@@ -642,6 +673,7 @@ class TtsNavigator(
         lastEngineConfig = EngineConfig(engineType, modelConfig, speed, pitch, language, speakerIndex)
         cancelShutdownTimer()
         scope.launchIO {  //切换到协程中执行
+            if (isShutdown) return@launchIO
             val oldEngineType = speech?.engineType ?: -1
             val oldModelConfig = speech?.config
             if (oldEngineType != engineType) {  //系统引擎 <-->  Sherpa引擎  两者之间切换
@@ -653,7 +685,8 @@ class TtsNavigator(
                         if (validTtsConfig(engineType, modelConfig)) {
                             speech = Speech.init(context, engineType, modelConfig, speed, pitch, language, speakerIndex) { status ->
                                 handleInitResult(newDeferred, status, "SherpaOnnx") //  通知等待者
-                                onInit( if (status == TextToSpeech.SUCCESS) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                releaseEngineIfShutdownRequested()
+                                onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
                             }
                         } else {
                             onInit(TtsEngineStatus.NEED_MODEL)
@@ -663,7 +696,8 @@ class TtsNavigator(
                     } else {
                         speech = Speech.init(context, speed, pitch, language) { status ->
                             handleInitResult(newDeferred, status, "BaseTTS")
-                            onInit( if (status == TextToSpeech.SUCCESS) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                            releaseEngineIfShutdownRequested()
+                            onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
                         }
                     }
                 } else {  //有其他引擎, 先关闭其他引擎
@@ -687,12 +721,14 @@ class TtsNavigator(
                         scope.launchIO {
                             delay(30)
                             Logger.i("TtsNavigator:setEngineInfo:wait shutdown last Engine then start new Engine.")
+                            if (isShutdown) return@launchIO
 
                             if (engineType == 1) {
                                 if (validTtsConfig(engineType, modelConfig)) {
                                     speech = Speech.init(context, engineType, modelConfig, speed, pitch, language, speakerIndex) { status ->
                                         handleInitResult(newDeferred, status, "SherpaOnnx") //  通知等待者
-                                        onInit( if (status == TextToSpeech.SUCCESS) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                        releaseEngineIfShutdownRequested()
+                                        onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
                                     }
                                 } else {
                                     onInit(TtsEngineStatus.NEED_MODEL)
@@ -702,7 +738,8 @@ class TtsNavigator(
                             } else {
                                 speech = Speech.init(context, speed, pitch, language) { status ->
                                     handleInitResult(newDeferred, status, "BaseTTS")
-                                    onInit( if (status == TextToSpeech.SUCCESS) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                    releaseEngineIfShutdownRequested()
+                                    onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
                                 }
                             }
                         }
@@ -735,11 +772,13 @@ class TtsNavigator(
                 oldSpeech?.shutdown {
                     scope.launchIO {
                         delay(30)
+                        if (isShutdown) return@launchIO
 
                         if (validTtsConfig(engineType, modelConfig)) {
                             speech = Speech.init(context, engineType, modelConfig, speed, pitch, language, speakerIndex) { status ->
                                 handleInitResult(newDeferred, status, "SherpaOnnx") //  通知等待者
-                                onInit( if (status == TextToSpeech.SUCCESS) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
+                                releaseEngineIfShutdownRequested()
+                                onInit(if (status == TextToSpeech.SUCCESS && !isShutdown) TtsEngineStatus.READY else TtsEngineStatus.FAILED)
                             }
                         } else {
                             onInit(TtsEngineStatus.NEED_MODEL)
@@ -849,7 +888,9 @@ class TtsNavigator(
 
     override fun shutdown(listener: OnShutdownListener?) {
         Logger.i("TtsNavigator:shutdown")
+        isShutdown = true
         playJob?.cancel()
+        engineInitJob?.cancel()
         cancelShutdownTimer()
 
         // 关闭 Channel
@@ -869,6 +910,9 @@ class TtsNavigator(
         }
         speech?.shutdown(listener)
         speech = null
+        scope.launch {
+            ProcessLifecycleOwner.get().lifecycle.removeObserver(this@TtsNavigator)
+        }
         Logger.i("TtsNavigator:shutdown completed")
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ junit = "4.13.2"
 junitVersion = "1.2.1"
 espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.7"
+lifecycleProcess = "2.8.7"
 activityCompose = "1.10.1"
 composeBom = "2025.02.00"
 materialIconsExtended = "1.7.8"
@@ -99,6 +100,7 @@ junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-process = { group = "androidx.lifecycle", name = "lifecycle-process", version.ref = "lifecycleProcess" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }

--- a/text2speech/src/main/java/net/gotev/speech/Speech.java
+++ b/text2speech/src/main/java/net/gotev/speech/Speech.java
@@ -98,15 +98,27 @@ public class Speech {
     /**
      * Must be called inside Activity's onDestroy.
      */
-    public synchronized void shutdown(OnShutdownListener shutdownListener) {
+    public synchronized void shutdown(final OnShutdownListener shutdownListener) {
         if (textToSpeechEngine != null) {
-            textToSpeechEngine.shutdown(shutdownListener);
+            textToSpeechEngine.shutdown(new OnShutdownListener() {
+                @Override
+                public void onDone() {
+                    instance = null;
+                    engineType = -1;
+                    if (shutdownListener != null) {
+                        shutdownListener.onDone();
+                    }
+                }
+            });
+        } else {
+            instance = null;
+            engineType = -1;
+            if (shutdownListener != null) {
+                shutdownListener.onDone();
+            }
         }
         textToSpeechEngine = null;
-
-        instance = null;
-        engineType = -1;
-        Logger.INSTANCE.d("Speech:shutdown:done");
+        Logger.INSTANCE.d("Speech:shutdown:invoked");
     }
 
     /**

--- a/text2speech/src/main/java/net/gotev/speech/engine/BaseTextToSpeechEngine.java
+++ b/text2speech/src/main/java/net/gotev/speech/engine/BaseTextToSpeechEngine.java
@@ -156,17 +156,22 @@ public class BaseTextToSpeechEngine implements TextToSpeechEngine {
     @Override
     public void shutdown(OnShutdownListener listener) {
         if (mTextToSpeech != null) {
+            mTtsCallbacks.clear();
             try {
-                mTtsCallbacks.clear();
                 mTextToSpeech.stop();
+            } catch (final Exception exc) {
+                Logger.INSTANCE.e(getClass().getSimpleName() + "Warning while stopping text to speech" + exc);
+            }
+            try {
                 mTextToSpeech.shutdown();
             } catch (final Exception exc) {
-                Logger.INSTANCE.e(getClass().getSimpleName() + "Warning while de-initing text to speech" + exc);
+                Logger.INSTANCE.e(getClass().getSimpleName() + "Warning while shutting down text to speech" + exc);
             } finally {
-                if (listener != null) {
-                    listener.onDone();
-                }
+                mTextToSpeech = null;
             }
+        }
+        if (listener != null) {
+            listener.onDone();
         }
     }
 


### PR DESCRIPTION
Ok, this one is a bit bigger than I expected. 

The main issue it fixes is allowing the system TTS engine to release and be stopped by Android when it's no more used by the software. Without this PR, as soon as you start TTS with the system's TTS, the engine will be lingering and will drain your battery in few hours.

The issues in the code were multiple, so here's a summary of what I've found and how it's fixed. I have used Claude to find the last leaking instances because I was going out of ideas.

1. First commit replaces the logic of a single engine instance that is never shutdown to a dynamic "create the engine only when required, shutdown when not"
2. Second commit detects when the app goes to the background to stop the TTS engine after some time (I've used 60s which is ok for me). I've added a ProcessLifeCycle observer for this task. 
3. Third commit spots the race conditions I've missed and fix the leaking TTS engine reference that was created when calling the "meta" function, like `getSupportedLanguage` or `getSpeed`

On a side quest, it also fix a missing "updateState" when crossing a chapter, that prevented the metadata (like track's `title`) to update on the Bluetooth player's screen.

I haven't translated the comments to Chinese. Let me know if you need it.  

 