### PR TITLE
Fix font size bug in TTS

### DIFF
--- a/app/src/main/java/com/wxn/reader/service/TtsPlaybackService.kt
+++ b/app/src/main/java/com/wxn/reader/service/TtsPlaybackService.kt
@@ -206,6 +206,11 @@ class TtsPlaybackService : MediaSessionService() {
     private var audioFocusRequest: AudioFocusRequest? = null
     private var audioFocusChangeListener: AudioManager.OnAudioFocusChangeListener? = null
 
+    // True when the current pause was triggered by a transient audio-focus loss
+    // (e.g. an incoming call). Lets us auto-resume on focus gain without resuming
+    // a pause the user requested manually.
+    private var pausedByFocusLoss = false
+
     private var lastCoverPath: String? = null
     private var lastArtworkData: ByteArray? = null
 
@@ -312,9 +317,11 @@ class TtsPlaybackService : MediaSessionService() {
                 val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
                 if (state.isPlaying) {
                     audioManager.requestAudioFocus(request)
-                } else {
-                    audioManager.abandonAudioFocusRequest(request)
                 }
+                // Do NOT abandon focus while merely paused: a transient loss (e.g. an
+                // incoming call) requires us to keep the request so the framework
+                // delivers AUDIOFOCUS_GAIN when the call ends and we can auto-resume.
+                // Focus is released for good in stopTts()/releaseAudioFocus().
             }
         }
     }
@@ -331,24 +338,64 @@ class TtsPlaybackService : MediaSessionService() {
         return START_STICKY
     }
 
+    // Explicitly acquire audio focus when playback (re)starts. This must NOT rely on
+    // the TtsState.isPlaying snapshot: at the point playback is kicked off the status is
+    // still PENDING_PLAYING (PLAYING is only set later from sentence-progress callbacks),
+    // so requesting focus off isPlaying would silently never happen and we would never
+    // receive focus-loss callbacks for incoming calls.
+    private fun acquireAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { request ->
+                val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+                audioManager.requestAudioFocus(request)
+            }
+        }
+    }
+
     private fun initAudioFocus() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val listener = AudioManager.OnAudioFocusChangeListener { focusChange ->
                 when (focusChange) {
-                    AudioManager.AUDIOFOCUS_LOSS -> pauseTts()
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> pauseTts()
-                    AudioManager.AUDIOFOCUS_GAIN -> resumeTts()
+                    // Permanent loss (another app took focus for good): pause and do
+                    // not arm auto-resume — no AUDIOFOCUS_GAIN will follow.
+                    AudioManager.AUDIOFOCUS_LOSS -> {
+                        pausedByFocusLoss = false
+                        pauseTts()
+                    }
+                    // Transient loss such as an incoming call. We also treat the
+                    // "can duck" case as a full pause: spoken content is useless at a
+                    // ducked volume, and setWillPauseWhenDucked(true) normally turns
+                    // ducking into a plain transient loss anyway. Only arm auto-resume
+                    // if we were actually playing, so a user pause is left untouched.
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                        if (ttsStateHolder.state.value.isPlaying) {
+                            pausedByFocusLoss = true
+                            pauseTts()
+                        }
+                    }
+                    // Focus regained (e.g. the call ended): resume only if we are the
+                    // ones who paused because of the focus loss.
+                    AudioManager.AUDIOFOCUS_GAIN -> {
+                        if (pausedByFocusLoss) {
+                            pausedByFocusLoss = false
+                            resumeTts()
+                        }
+                    }
                 }
             }
             audioFocusChangeListener = listener
             audioFocusRequest =
-                AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
+                AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
                     .setAudioAttributes(
                         android.media.AudioAttributes.Builder()
                             .setUsage(android.media.AudioAttributes.USAGE_MEDIA)
                             .setContentType(android.media.AudioAttributes.CONTENT_TYPE_SPEECH)
                             .build()
                     )
+                    // Speech must not be ducked to a low volume; ask the framework to
+                    // send us a transient loss (so we pause) instead of auto-ducking.
+                    .setWillPauseWhenDucked(true)
                     .setOnAudioFocusChangeListener(listener)
                     .build()
         }
@@ -382,6 +429,9 @@ class TtsPlaybackService : MediaSessionService() {
 
     fun resumeTts() {
         Logger.i("TtsPlaybackService: resumeTts")
+        // Once playback resumes there is no pending focus-loss pause to recover from.
+        pausedByFocusLoss = false
+        acquireAudioFocus()
         scope.launchMain {
             ttsStateHolder.startPlaying()
             ttsStateHolder.startTimerSession()
@@ -398,6 +448,7 @@ class TtsPlaybackService : MediaSessionService() {
      */
     fun stopTts() {
         Logger.i("TtsPlaybackService: stopTts")
+        pausedByFocusLoss = false
         ttsStateHolder.stopPlaying()
         ttsNavigator?.stop()
         mediaSession?.player?.stop()
@@ -569,6 +620,7 @@ class TtsPlaybackService : MediaSessionService() {
                             }
                             scope.launchMain {
                                 ttsStateHolder.startTimerSession()
+                                acquireAudioFocus()
                                 navigator.play()
                                 mediaSession?.player?.play()
                                 updateState(ttsStateHolder.state.value)

--- a/mobi/src/main/cpp/util/epub_util.cpp
+++ b/mobi/src/main/cpp/util/epub_util.cpp
@@ -1273,6 +1273,14 @@ int epub_util::getChapter(JNIEnv *env, long book_id,
         }
 
         currentSrc = spineSrc;
+        // Cache the CSS with the document it was parsed from: the branch above is skipped when the
+        // same spine document is requested twice in a row, and cssInfos would then stay empty.
+        currentCssInfos = cssInfos;
+    } else {
+        // Same spine document as the previous call — `doc` is still the parsed one, so reuse its
+        // CSS. Without this the chapter gets paginated with no publisher stylesheet at all, making
+        // the rendered font size depend on the order in which chapters happen to be loaded.
+        cssInfos = currentCssInfos;
     }
 
     if (!run_flag) {

--- a/mobi/src/main/cpp/util/epub_util.h
+++ b/mobi/src/main/cpp/util/epub_util.h
@@ -74,6 +74,7 @@ public:
         }
         allChapters.clear();
         currentSrc = "";
+        currentCssInfos.clear();
         isEmptyCss = false;
     }
 
@@ -83,6 +84,7 @@ public:
         doc.ClearError();
         doc.Clear();
         currentSrc = "";
+        currentCssInfos.clear();
         isSingleSrc = false;
         isEmptyCss = false;
         epub_release();
@@ -148,6 +150,13 @@ private:
     mutable std::mutex m_Mutex4;
     unzFile bookzip;
     std::string currentSrc;
+    /**
+     * CSS parsed for [currentSrc]. Must be cached together with the `doc` / [currentSrc] pair:
+     * getChapter() only re-reads and re-parses the spine document when spineSrc != currentSrc, so
+     * a repeat call for the same document has to reuse this instead of applying no CSS at all
+     * (which silently paginated the chapter without the publisher stylesheet).
+     */
+    std::vector<CssInfo> currentCssInfos;
     bool isEmptyCss;
     std::vector<BookManifest> manifests;
     std::vector<BookSpine> spines;

--- a/mobi/src/main/cpp/util/mobi_util.cpp
+++ b/mobi/src/main/cpp/util/mobi_util.cpp
@@ -1049,6 +1049,14 @@ int mobi_util::getChapter(JNIEnv *env,
         }
 
         currentSrc = spineSrc;
+        // Cache the CSS with the document it was parsed from: the branch above is skipped when the
+        // same spine document is requested twice in a row, and cssInfos would then stay empty.
+        currentCssInfos = cssInfos;
+    } else {
+        // Same spine document as the previous call — `doc` is still the parsed one, so reuse its
+        // CSS. Without this the chapter gets paginated with no publisher stylesheet at all, making
+        // the rendered font size depend on the order in which chapters happen to be loaded.
+        cssInfos = currentCssInfos;
     }
 
     if (!run_flag) {

--- a/mobi/src/main/cpp/util/mobi_util.h
+++ b/mobi/src/main/cpp/util/mobi_util.h
@@ -68,6 +68,7 @@ public:
         }
         allChapters.clear();
         currentSrc = "";
+        currentCssInfos.clear();
     }
 
     /***
@@ -80,6 +81,7 @@ public:
         doc.ClearError();
         doc.Clear();
         currentSrc = "";
+        currentCssInfos.clear();
         isSingleSrc = false;
     }
 
@@ -121,6 +123,12 @@ private:
     MOBIData *mobi_data;
 
     std::string currentSrc;
+    /**
+     * CSS parsed for [currentSrc] — cached with the `doc` / [currentSrc] pair, since getChapter()
+     * only re-reads and re-parses the spine document when spineSrc != currentSrc. A repeat call for
+     * the same document must reuse this rather than apply no CSS at all.
+     */
+    std::vector<CssInfo> currentCssInfos;
 
     int init();
 


### PR DESCRIPTION
The issue isn't in the Kotlin code, but in the C++ code that's using a temporary for cssInfos that's only filled on first call.
Next call leave the temporary empty and thus, the book's CSS isn't used on 2nd and later calls while it's used on first call.

It was visible when starting TTS since it causes a relayout of the text.

The file of interest are epub_util.cpp (and mobi_util.cpp), around line 1189 (creation of local cssInfos).
Then there's a test "if (spineSrc != currentSrc)" that'll fill cssInfos only if not cached yet.
If it's not the case (on 2nd call, where spineSrc == currentSrc), then handle_tags on line 1326 will use an empty cssInfos leading to error in reported font size to Kotlin.

The fix here is to cache the cssInfos once it's parsed in the 2 files using the same scheme, like the spine source is cached.

This one applies on the previous PR for call pause fixing.l 
